### PR TITLE
Add Mattermost plugin to fluentd v1.14

### DIFF
--- a/v1.14/Dockerfile
+++ b/v1.14/Dockerfile
@@ -77,6 +77,7 @@ RUN apk update \
          fluent-plugin-sqs \
          fluent-plugin-kube-events-timestamp \
          fluent-plugin-grok-parser \
+         fluent-plugin-mattermost \
  && gem specific_install -l https://github.com/tarokkk/fluent-plugin-logzio.git \
  && gem specific_install -l https://github.com/acquia/fluent-plugin-syslog_rfc5424.git \
  && gem specific_install -l https://github.com/banzaicloud/fluent-plugin-gcs.git \


### PR DESCRIPTION
This PR adds output mattermost [plugin](https://github.com/levigo-systems/fluent-plugin-mattermost).
Relates to https://github.com/kube-logging/logging-operator/pull/1200