### PR TITLE
feat: bump up fluent-plugin-gcs version to 0.4.3

### DIFF
--- a/v1.16-ruby3.2/Dockerfile
+++ b/v1.16-ruby3.2/Dockerfile
@@ -90,7 +90,7 @@ USER root
 
 RUN apk add --no-cache $BUILD_DEPS \
  && touch /etc/gemrc \
- && fluent-gem specific_install -l https://github.com/kube-logging/fluent-plugin-gcs.git --ref 71a0932e75509545a2d28e337642ee1f973cca90 \
+ && fluent-gem specific_install -l https://github.com/kube-logging/fluent-plugin-gcs.git --ref f18a48914cc0e09df313791c947ca7eb3d0d0148 \
  && fluent-gem specific_install -l https://github.com/acquia/fluent-plugin-syslog_rfc5424.git --ref 5199be67d1a385f529fa1d6b6023e95ba7fac27d \
  && fluent-gem install --file /Gemfile.outputs \
  && find /usr/local/bundle/gems/ -newer /etc/gemrc -exec chown fluent:fluent {} \; \

--- a/v1.16-ruby3.2/Dockerfile
+++ b/v1.16-ruby3.2/Dockerfile
@@ -90,7 +90,8 @@ USER root
 
 RUN apk add --no-cache $BUILD_DEPS \
  && touch /etc/gemrc \
- && fluent-gem specific_install -l https://github.com/kube-logging/fluent-plugin-gcs.git --ref f18a48914cc0e09df313791c947ca7eb3d0d0148 \
+ # TODO get rid of this by submitting the patch upstream
+ && fluent-gem specific_install -l https://github.com/kube-logging/fluent-plugin-gcs.git --ref ad6a7cb0f166e2c1648954a928e1e9b8cdcbf93d \
  && fluent-gem specific_install -l https://github.com/acquia/fluent-plugin-syslog_rfc5424.git --ref 5199be67d1a385f529fa1d6b6023e95ba7fac27d \
  && fluent-gem install --file /Gemfile.outputs \
  && find /usr/local/bundle/gems/ -newer /etc/gemrc -exec chown fluent:fluent {} \; \

--- a/v1.16/Dockerfile
+++ b/v1.16/Dockerfile
@@ -86,7 +86,8 @@ USER root
 
 RUN apk add --no-cache $BUILD_DEPS \
  && touch /etc/gemrc \
- && fluent-gem specific_install -l https://github.com/kube-logging/fluent-plugin-gcs.git --ref f18a48914cc0e09df313791c947ca7eb3d0d0148 \
+ # TODO get rid of this by submitting the patch upstream
+ && fluent-gem specific_install -l https://github.com/kube-logging/fluent-plugin-gcs.git --ref ad6a7cb0f166e2c1648954a928e1e9b8cdcbf93d \
  && fluent-gem specific_install -l https://github.com/acquia/fluent-plugin-syslog_rfc5424.git --ref 5199be67d1a385f529fa1d6b6023e95ba7fac27d \
  && fluent-gem install --file /Gemfile.outputs \
  && find /usr/local/bundle/gems/ -newer /etc/gemrc -exec chown fluent:fluent {} \; \

--- a/v1.16/Dockerfile
+++ b/v1.16/Dockerfile
@@ -86,7 +86,7 @@ USER root
 
 RUN apk add --no-cache $BUILD_DEPS \
  && touch /etc/gemrc \
- && fluent-gem specific_install -l https://github.com/kube-logging/fluent-plugin-gcs.git --ref 71a0932e75509545a2d28e337642ee1f973cca90 \
+ && fluent-gem specific_install -l https://github.com/kube-logging/fluent-plugin-gcs.git --ref f18a48914cc0e09df313791c947ca7eb3d0d0148 \
  && fluent-gem specific_install -l https://github.com/acquia/fluent-plugin-syslog_rfc5424.git --ref 5199be67d1a385f529fa1d6b6023e95ba7fac27d \
  && fluent-gem install --file /Gemfile.outputs \
  && find /usr/local/bundle/gems/ -newer /etc/gemrc -exec chown fluent:fluent {} \; \


### PR DESCRIPTION
This feature changes the fluent-plugin-gcs source and bumps up the version from 0.4.0 to 0.4.3. Also, we expect to resolve some issue regarding the error "_got unrecoverable error in primary and no secondary error_class=ArgumentError error="wrong number of arguments (given 2, expected 1)_" when we try to use the GCS.