### PR TITLE
feat: add openssl-dev for kafka tls support

### DIFF
--- a/v1.16-4.10/Dockerfile
+++ b/v1.16-4.10/Dockerfile
@@ -9,7 +9,7 @@ ARG BUILD_DEPS=" \
       wget bzip2 zlib-dev git linux-headers \
       automake autoconf libtool build-base \
       ruby-dev libc6-compat geoip-dev \
-      snappy-dev gnupg bash \
+      snappy-dev gnupg bash openssl-dev \
       "
 
 RUN addgroup -S -g 101 fluent && adduser -S -G fluent -u 100 fluent \


### PR DESCRIPTION
Add tls support for the kafka output as requested in:
https://github.com/kube-logging/logging-operator/issues/1802

