### PR TITLE
alias for 4.11 instead a full identical build

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -18,10 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         fluentd:
-          - v1.16-4.8
-          - v1.16-4.9
-          - v1.16-4.10
-          - v1.17-5.0
+          - version: v1.16-4.8
+          - version: v1.16-4.9
+          - version: v1.16-4.10
+            alias:   v1.16-4.11
+          - version: v1.17-5.0
         image-type:
           - base
           - filters
@@ -40,9 +41,10 @@ jobs:
           flavor: |
             latest = false
           tags: |
-            type=raw,value=${{ matrix.fluentd }}-${{ matrix.image-type }}
-            type=raw,value=${{ matrix.fluentd }}-${{ matrix.image-type }}-build.${{ github.run_number }}
-
+            type=raw,value=${{ matrix.fluentd.version }}-${{ matrix.image-type }}
+            type=raw,value=${{ matrix.fluentd.version }}-${{ matrix.image-type }}-build.${{ github.run_number }}
+            type=raw,value=${{ !!matrix.fluentd.alias && matrix.fluentd.alias || 'alias' }}-${{ matrix.image-type }},enable=${{ !!matrix.fluentd.alias }}
+            type=raw,value=${{ !!matrix.fluentd.alias && matrix.fluentd.alias || 'alias' }}-${{ matrix.image-type }}-build.${{ github.run_number }},enable=${{ !!matrix.fluentd.alias }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -63,7 +65,7 @@ jobs:
       - name: Build and push (${{ matrix.image-type }})
         uses: docker/build-push-action@v5
         with:
-          context: ${{ matrix.fluentd }}
+          context: ${{ matrix.fluentd.version }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         fluentd:
-          - v1.16-4.8
-          - v1.16-4.9
-          - v1.16-4.10
-          - v1.17-5.0
+          - version: v1.16-4.8
+          - version: v1.16-4.9
+          - version: v1.16-4.10
+            alias:   v1.16-4.11
+          - version: v1.17-5.0
         image-type:
           - base
           - filters
@@ -33,14 +34,16 @@ jobs:
           flavor: |
             latest = false
           tags: |
-            type=raw,value=${{ matrix.fluentd }}-${{ matrix.image-type }}-build.${{ github.run_number }}
-            type=raw,value=${{ matrix.fluentd }}-${{ matrix.image-type }}
+            type=raw,value=${{ matrix.fluentd.version }}-${{ matrix.image-type }}
+            type=raw,value=${{ matrix.fluentd.version }}-${{ matrix.image-type }}-build.${{ github.run_number }}
+            type=raw,value=${{ !!matrix.fluentd.alias && matrix.fluentd.alias || 'alias' }}-${{ matrix.image-type }},enable=${{ !!matrix.fluentd.alias }}
+            type=raw,value=${{ !!matrix.fluentd.alias && matrix.fluentd.alias || 'alias' }}-${{ matrix.image-type }}-build.${{ github.run_number }},enable=${{ !!matrix.fluentd.alias }}
           labels: |
             org.opencontainers.image.description=Custom-built Fluentd image for the Logging operator
             org.opencontainers.image.title=Fluentd docker image
             org.opencontainers.image.authors=kube-logging authors
             org.opencontainers.image.documentation=https://kube-logging.dev/docs/
-            org.opencontainers.image.version=${{ matrix.fluentd }}-${{ matrix.image-type }}
+            org.opencontainers.image.version=${{ matrix.fluentd.version }}-${{ matrix.image-type }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -56,7 +59,7 @@ jobs:
       - name: Build image (${{ matrix.image-type }})
         uses: docker/build-push-action@v5
         with:
-          context: ${{ matrix.fluentd }}
+          context: ${{ matrix.fluentd.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: false


### PR DESCRIPTION
Logging operator version 4.11 will be a release that doesn't require a specific new image, instead we want that to be identical to 4.10 for now. We still want a separate image tag for it in order to be able to make changes separately later if needed.

Signed-off-by: Peter Wilcsinszky <peter.wilcsinszky@axoflow.com>
