### PR TITLE
chore: use stable trivy db refs

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -82,6 +82,9 @@ jobs:
           format: "sarif"
           output: "trivy-results.sarif"
         if: github.event_name == 'push'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:1
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
Signed-off-by: Peter Wilcsinszky <peter.wilcsinszky@axoflow.com>
