### PR TITLE
chore: limit ruby bumps for patch versions only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,11 @@
         {
             "matchUpdateTypes": ["major"],
             "enabled": false
+        },
+        {
+            "matchPackageNames": ["ruby"],
+            "matchUpdateTypes": ["major", "minor"],
+            "enabled": false
         }
     ]
 }


### PR DESCRIPTION
Signed-off-by: Peter Wilcsinszky <peter.wilcsinszky@axoflow.com>
