### PR TITLE
fix: add 'ruby-bigdecimal' to solve 'Oj is not installed, and falling…

### DIFF
--- a/v1.16-4.10/Dockerfile
+++ b/v1.16-4.10/Dockerfile
@@ -10,6 +10,7 @@ ARG BUILD_DEPS=" \
       automake autoconf libtool build-base \
       ruby-dev libc6-compat geoip-dev \
       snappy-dev gnupg bash openssl-dev \
+      ruby-bigdecimal \
       "
 
 RUN addgroup -S -g 101 fluent && adduser -S -G fluent -u 100 fluent \

--- a/v1.17-5.0/Dockerfile
+++ b/v1.17-5.0/Dockerfile
@@ -6,6 +6,7 @@ ARG BUILD_DEPS=" \
       automake autoconf libtool build-base \
       ruby-dev libc6-compat geoip-dev \
       snappy-dev gnupg bash openssl-dev \
+      ruby-bigdecimal \
       "
 
 RUN addgroup -S -g 101 fluent && adduser -S -G fluent -u 100 fluent \


### PR DESCRIPTION
… back to Yajl for json parser'

FluentD docs: https://docs.fluentd.org/quickstart/faq#fluentd-warns-oj-is-not-installed-and-falling-back-to-yajl-for-json-parser