### PR TITLE
fix: PATH_MAX unset error during full builds

### DIFF
--- a/v1.16-4.10/Dockerfile
+++ b/v1.16-4.10/Dockerfile
@@ -1,8 +1,8 @@
 # TODO every time the base image is changed please make sure BASEIMAGEDEPS is updated (further down in this file)
 # https://gallery.ecr.aws/sumologic/kubernetes-fluentd
-FROM public.ecr.aws/sumologic/kubernetes-fluentd:1.16.5-sumo-0-alpine as sumo
+FROM public.ecr.aws/sumologic/kubernetes-fluentd:1.16.5-sumo-0-alpine AS sumo
 
-FROM ruby:3.2.5-alpine3.20 as base
+FROM ruby:3.2.5-alpine3.20 AS base
 
 ARG BUILD_DEPS=" \
       make gcc g++ libc-dev \
@@ -83,7 +83,7 @@ RUN apk add --no-cache $BUILD_DEPS \
 USER fluent
 
 ### Image with all the filters and outputs
-FROM filters as full
+FROM filters AS full
 
 ADD ./outputs/Gemfile /Gemfile.outputs
 ADD ./outputs/Gemfile.lock /Gemfile.outputs.lock

--- a/v1.17-5.0/Dockerfile
+++ b/v1.17-5.0/Dockerfile
@@ -71,6 +71,7 @@ ADD ./outputs/Gemfile.lock /Gemfile.outputs.lock
 USER root
 
 RUN apk add --no-cache $BUILD_DEPS \
+ && apk del fortify-headers \
  && touch /etc/gemrc \
  && fluent-gem specific_install -l https://github.com/kube-logging/fluent-plugin-syslog_rfc5424.git --ref 4ab9f7df3757b0e31e4bc209acab05a518efdce3 \
  && fluent-gem install --file /Gemfile.outputs \

--- a/v1.17-5.0/Dockerfile
+++ b/v1.17-5.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3.6-alpine3.20 as base
+FROM ruby:3.3.6-alpine3.20 AS base
 
 ARG BUILD_DEPS=" \
       make gcc g++ libc-dev \
@@ -63,7 +63,7 @@ RUN apk add --no-cache $BUILD_DEPS \
 USER fluent
 
 ### Image with all the filters and outputs
-FROM filters as full
+FROM filters AS full
 
 ADD ./outputs/Gemfile /Gemfile.outputs
 ADD ./outputs/Gemfile.lock /Gemfile.outputs.lock


### PR DESCRIPTION
We have faced a similar issue in the [loggig-operator](https://github.com/kube-logging/logging-operator/pull/2087/commits/0b7600e804cd6b67eebbc23e4a1b6b733399d4bd) before the 6.0.3 release.

The problem occurred because:

- Alpine Linux includes fortified versions of standard C library functions in the fortify-headers package. These are security-hardened versions that add runtime checks.
- The fortified realpath() function requires PATH_MAX to be defined, but some build environments (particularly when compiling gems with native extensions) don't properly set this macro.
- When installing gems that include native extensions, the compilation process tried to use the fortified headers but failed due to the missing PATH_MAX definition.
- By removing the `fortify-headers` package before the gem installation, the standard library functions will be used, therefore the realpath() won't have the same strict requirements as in the fortified version.
