### PR TITLE
fix: PATH_MAX unset error during full builds

### DIFF
--- a/v1.17-5.0/Dockerfile
+++ b/v1.17-5.0/Dockerfile
@@ -71,7 +71,7 @@ ADD ./outputs/Gemfile.lock /Gemfile.outputs.lock
 USER root
 
 RUN apk add --no-cache $BUILD_DEPS \
- && apk del fortify-headers \
+ && rm -rf /usr/include/fortify \
  && touch /etc/gemrc \
  && fluent-gem specific_install -l https://github.com/kube-logging/fluent-plugin-syslog_rfc5424.git --ref 4ab9f7df3757b0e31e4bc209acab05a518efdce3 \
  && fluent-gem install --file /Gemfile.outputs \


### PR DESCRIPTION
It looks like deleting the `fortify-headers` package before install does not solve the problem, let's fallback to the original solution.