### PR TITLE
add snappy gem for fluentd 1.17

### DIFF
--- a/v1.17-5.0/Dockerfile
+++ b/v1.17-5.0/Dockerfile
@@ -26,6 +26,7 @@ RUN addgroup -S -g 101 fluent && adduser -S -G fluent -u 100 fluent \
  && gem install fluentd -v 1.17.1 \
  && fluent-gem install specific_install -v 0.3.8 \
  && fluent-gem install fluent-plugin-label-router -v 0.4.0 \
+ && fluent-gem install snappy -v 0.0.15 \
  && find /usr/local/bundle/gems/ -newer /etc/gemrc -exec chown fluent:fluent {} \; \
  && apk del $BUILD_DEPS \
  && rm -rf /usr/local/bundle/cache/* && find /usr/local/bundle -name '*.o' -delete


### PR DESCRIPTION
fixes #97 (again)

Ahoy @pepov  :-)

We are back with our snappy issue (using compression in Kafka output). Fixed here for the fluentd 1.17 image. 1.18 will be follow in the Operator repo.  Tested both on our platform and works so far.